### PR TITLE
Add pip packaging and GitHub Actions CI/publish pipelines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Build and verify package
+        run: |
+          pip install build
+          python -m build
+          pip install dist/*.whl
+          python -c "import omnifold; print(f'omnifold v{omnifold.__version__} OK')"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE
+include README.md
+exclude *.ipynb
+prune Benchmark
+prune img
+prune .github

--- a/omnifold.py
+++ b/omnifold.py
@@ -1,3 +1,5 @@
+__version__ = "0.1.0"
+
 import numpy as np
 import tensorflow as tf
 import tensorflow.keras.backend as K

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "omnifold"
+dynamic = ["version"]
+description = "OmniFold: iterative unfolding with machine learning"
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.8"
+authors = [
+    {name = "Anders Andreassen"},
+    {name = "Patrick Komiske"},
+    {name = "Eric Metodiev"},
+    {name = "Benjamin Nachman"},
+    {name = "Adi Suresh"},
+    {name = "Jesse Thaler"},
+]
+dependencies = [
+    "numpy",
+    "scikit-learn",
+    "tensorflow>=2.0",
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Intended Audience :: Science/Research",
+]
+
+[project.urls]
+Homepage = "https://github.com/hep-lbdl/OmniFold"
+Issues = "https://github.com/hep-lbdl/OmniFold/issues"
+
+[tool.setuptools]
+py-modules = ["omnifold"]
+
+[tool.setuptools.dynamic]
+version = {attr = "omnifold.__version__"}


### PR DESCRIPTION
## Summary

Resolves #7 — adds packaging support so OmniFold can be built, tested, and published to PyPI using GitHub Actions.

This PR sets up the basic packaging infrastructure along with CI and a release workflow for publishing the package.

---

## Changes

**pyproject.toml**

- Adds modern PEP 621 package configuration
- Defines project metadata and dependencies:
  - numpy
  - scikit-learn
  - tensorflow>=2.0
- Uses dynamic versioning from `omnifold.__version__`

**omnifold.py**

- Adds:

```python
__version__ = "0.1.0"