### PR TITLE
Fix typo in efficiency factors section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # <img src="img/omnifold_logo.png" width="100"> OmniFold
 
-This repository contains simple examples of implementing the OmniFold algorithm originally described in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001), [1911.09107 [hep-ph]](https://arxiv.org/abs/1911.09107).  The code for the original paper can be found at [this repository](https://github.com/ericmetodiev/OmniFold), which includes a [binder demo](https://mybinder.org/v2/gh/ericmetodiev/OmniFold/master).  This repository includes simple examples that do not depend on the [energyflow package](https://energyflow.network).
+This repository contains simple examples of implementing the OmniFold algorithm originally described in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001), [1911.09107 [hep-ph]](https://arxiv.org/abs/1911.09107). The code for the original paper can be found at [this repository](https://github.com/ericmetodiev/OmniFold), which includes a [binder demo](https://mybinder.org/v2/gh/ericmetodiev/OmniFold/master). This repository includes simple examples that do not depend on the [energyflow package](https://energyflow.network).
 
 The main example is in the notebook `GaussianExample.ipynb` which performs all four functions of a complete unfolding algorithm:
 
-1. **Background subtraction**. In many cases, one has an estimate of a background process that you would like to remove before correcting for detector effects.  For example, you may want to measure spectra in top quark pair production, but want to subtract the contribution from W+jets.  In the notebook, this is controlled by `back` which is set to 0.1 as a default. Unbinned subtraction is achieved using [neural positive reweighting](https://arxiv.org/abs/2007.11586).
-2. **Fake factors**.  Events that pass the detector-level event selection, but not the particle-level one.  These events participate in Step 1 of OmniFold, but not Step 2.  The rate of these events are controlled by `fake` which is set to 0.1 by default.  You should also change `dummyval` to be some value that is unlikely to occur (set to -10 by default).
-3. **Resolution effects**.  This step does most of the heavy lifting in OmniFold and is the main part of the algorithm.  The procedure is iterative, with the number of iterations set by `iterations`.
-4. **Efficiency factors**.  Events that pass the particle-level event selection, but not the particle-level one.  One option for these events is to simply take the prior, which is the option `weights_pull[theta0_S==dummyval] = 1.` in the code.  Another option (which is on by default) is to set the pulled-back weights for such events to be equal to the average weight: _w = E[w(reco)|true]_.  This also uses the [neural positive reweighting](https://arxiv.org/abs/2007.11586).
+1. **Background subtraction**. In many cases, one has an estimate of a background process that you would like to remove before correcting for detector effects. For example, you may want to measure spectra in top quark pair production, but want to subtract the contribution from W+jets. In the notebook, this is controlled by `back` which is set to 0.1 as a default. Unbinned subtraction is achieved using [neural positive reweighting](https://arxiv.org/abs/2007.11586).
+2. **Fake factors**. Events that pass the detector-level event selection, but not the particle-level one. These events participate in Step 1 of OmniFold, but not Step 2. The rate of these events are controlled by `fake` which is set to 0.1 by default. You should also change `dummyval` to be some value that is unlikely to occur (set to -10 by default).
+3. **Resolution effects**. This step does most of the heavy lifting in OmniFold and is the main part of the algorithm. The procedure is iterative, with the number of iterations set by `iterations`.
+4. **Efficiency factors**. Events that pass the particle-level event selection, but not the detector-level one. One option for these events is to simply take the prior, which is the option `weights_pull[theta0_S==dummyval] = 1.` in the code. Another option (which is on by default) is to set the pulled-back weights for such events to be equal to the average weight: _w = E[w(reco)|true]_. This also uses the [neural positive reweighting](https://arxiv.org/abs/2007.11586).
 
-If you are not worried about (1), (2), or (4) and would simply like to do deconvolution, then you can see the script `GaussianExample_mimimal.ipynb` which calls the OmniFold algorithm in `omnifold.py`.  The Jupyter notebook is simply used to show the results - all that you need to do are specify a TensorFlow model and pass in the data to `omnifold.omnifold`.
+If you are not worried about (1), (2), or (4) and would simply like to do deconvolution, then you can see the script `GaussianExample_mimimal.ipynb` which calls the OmniFold algorithm in `omnifold.py`. The Jupyter notebook is simply used to show the results - all that you need to do are specify a TensorFlow model and pass in the data to `omnifold.omnifold`.
 
 ### Further explanation
 
@@ -27,21 +27,24 @@ Here are some recent presentations that further explain the OmniFold approach:
 
 ### Name
 
-The name OmniFold refers generally to the iterative reweighting algorithm introduced in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001).  One- and multi-dimensional variants are sometimes called Unifold and Multifold, respectively.  The name OmniFold originates from a poem by Emily Dickinson:
+The name OmniFold refers generally to the iterative reweighting algorithm introduced in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001). One- and multi-dimensional variants are sometimes called Unifold and Multifold, respectively. The name OmniFold originates from a poem by Emily Dickinson:
 
-Emily Dickinson, \#975  
->The Mountain sat upon the Plain  
->In his tremendous Chair&mdash;  
->His observation omnifold,  
->His inquest, everywhere&mdash;  
->  
->The Seasons played around his knees  
->Like Children round a sire&mdash;  
->Grandfather of the Days is He  
->Of Dawn, the Ancestor&mdash;  
+Emily Dickinson, \#975
+
+> The Mountain sat upon the Plain  
+> In his tremendous Chair&mdash;  
+> His observation omnifold,  
+> His inquest, everywhere&mdash;
+>
+> The Seasons played around his knees  
+> Like Children round a sire&mdash;  
+> Grandfather of the Days is He  
+> Of Dawn, the Ancestor&mdash;
 
 ### Citation
+
 If you use OmniFold, please cite:
+
 ```
 @article{Andreassen:2019cjw,
     author = "Andreassen, Anders and Komiske, Patrick T. and Metodiev, Eric M. and Nachman, Benjamin and Thaler, Jesse",


### PR DESCRIPTION
Fix a typo in the efficiency factors section of the README.

The sentence incorrectly referred to "particle-level" twice and is corrected to "detector-level".

The GaussianExample notebook mentioned in issue #3 appears to already be correct in the current version of the repository. A separate issue/PR was opened for a TensorFlow/Keras compatibility problem encountered when running the example with modern versions.

Closes #3