### PR TITLE
Fix numerical instability in reweighting step by clipping classifier outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # <img src="img/omnifold_logo.png" width="100"> OmniFold
 
-This repository contains simple examples of implementing the OmniFold algorithm originally described in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001), [1911.09107 [hep-ph]](https://arxiv.org/abs/1911.09107).  The code for the original paper can be found at [this repository](https://github.com/ericmetodiev/OmniFold), which includes a [binder demo](https://mybinder.org/v2/gh/ericmetodiev/OmniFold/master).  This repository includes simple examples that do not depend on the [energyflow package](https://energyflow.network).
+This repository contains simple examples of implementing the OmniFold algorithm originally described in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001), [1911.09107 [hep-ph]](https://arxiv.org/abs/1911.09107). The code for the original paper can be found at [this repository](https://github.com/ericmetodiev/OmniFold), which includes a [binder demo](https://mybinder.org/v2/gh/ericmetodiev/OmniFold/master). This repository includes simple examples that do not depend on the [energyflow package](https://energyflow.network).
 
 The main example is in the notebook `GaussianExample.ipynb` which performs all four functions of a complete unfolding algorithm:
 
-1. **Background subtraction**. In many cases, one has an estimate of a background process that you would like to remove before correcting for detector effects.  For example, you may want to measure spectra in top quark pair production, but want to subtract the contribution from W+jets.  In the notebook, this is controlled by `back` which is set to 0.1 as a default. Unbinned subtraction is achieved using [neural positive reweighting](https://arxiv.org/abs/2007.11586).
-2. **Fake factors**.  Events that pass the detector-level event selection, but not the particle-level one.  These events participate in Step 1 of OmniFold, but not Step 2.  The rate of these events are controlled by `fake` which is set to 0.1 by default.  You should also change `dummyval` to be some value that is unlikely to occur (set to -10 by default).
-3. **Resolution effects**.  This step does most of the heavy lifting in OmniFold and is the main part of the algorithm.  The procedure is iterative, with the number of iterations set by `iterations`.
-4. **Efficiency factors**.  Events that pass the particle-level event selection, but not the particle-level one.  One option for these events is to simply take the prior, which is the option `weights_pull[theta0_S==dummyval] = 1.` in the code.  Another option (which is on by default) is to set the pulled-back weights for such events to be equal to the average weight: _w = E[w(reco)|true]_.  This also uses the [neural positive reweighting](https://arxiv.org/abs/2007.11586).
+1. **Background subtraction**. In many cases, one has an estimate of a background process that you would like to remove before correcting for detector effects. For example, you may want to measure spectra in top quark pair production, but want to subtract the contribution from W+jets. In the notebook, this is controlled by `back` which is set to 0.1 as a default. Unbinned subtraction is achieved using [neural positive reweighting](https://arxiv.org/abs/2007.11586).
+2. **Fake factors**. Events that pass the detector-level event selection, but not the particle-level one. These events participate in Step 1 of OmniFold, but not Step 2. The rate of these events are controlled by `fake` which is set to 0.1 by default. You should also change `dummyval` to be some value that is unlikely to occur (set to -10 by default).
+3. **Resolution effects**. This step does most of the heavy lifting in OmniFold and is the main part of the algorithm. The procedure is iterative, with the number of iterations set by `iterations`.
+4. **Efficiency factors**. Events that pass the particle-level event selection, but not the detector-level one. One option for these events is to simply take the prior, which is the option `weights_pull[theta0_S==dummyval] = 1.` in the code. Another option (which is on by default) is to set the pulled-back weights for such events to be equal to the average weight: _w = E[w(reco)|true]_. This also uses the [neural positive reweighting](https://arxiv.org/abs/2007.11586).
 
-If you are not worried about (1), (2), or (4) and would simply like to do deconvolution, then you can see the script `GaussianExample_mimimal.ipynb` which calls the OmniFold algorithm in `omnifold.py`.  The Jupyter notebook is simply used to show the results - all that you need to do are specify a TensorFlow model and pass in the data to `omnifold.omnifold`.
+If you are not worried about (1), (2), or (4) and would simply like to do deconvolution, then you can see the script `GaussianExample_mimimal.ipynb` which calls the OmniFold algorithm in `omnifold.py`. The Jupyter notebook is simply used to show the results - all that you need to do are specify a TensorFlow model and pass in the data to `omnifold.omnifold`.
 
 ### Further explanation
 
@@ -27,21 +27,24 @@ Here are some recent presentations that further explain the OmniFold approach:
 
 ### Name
 
-The name OmniFold refers generally to the iterative reweighting algorithm introduced in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001).  One- and multi-dimensional variants are sometimes called Unifold and Multifold, respectively.  The name OmniFold originates from a poem by Emily Dickinson:
+The name OmniFold refers generally to the iterative reweighting algorithm introduced in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001). One- and multi-dimensional variants are sometimes called Unifold and Multifold, respectively. The name OmniFold originates from a poem by Emily Dickinson:
 
-Emily Dickinson, \#975  
->The Mountain sat upon the Plain  
->In his tremendous Chair&mdash;  
->His observation omnifold,  
->His inquest, everywhere&mdash;  
->  
->The Seasons played around his knees  
->Like Children round a sire&mdash;  
->Grandfather of the Days is He  
->Of Dawn, the Ancestor&mdash;  
+Emily Dickinson, \#975
+
+> The Mountain sat upon the Plain  
+> In his tremendous Chair&mdash;  
+> His observation omnifold,  
+> His inquest, everywhere&mdash;
+>
+> The Seasons played around his knees  
+> Like Children round a sire&mdash;  
+> Grandfather of the Days is He  
+> Of Dawn, the Ancestor&mdash;
 
 ### Citation
+
 If you use OmniFold, please cite:
+
 ```
 @article{Andreassen:2019cjw,
     author = "Andreassen, Anders and Komiske, Patrick T. and Metodiev, Eric M. and Nachman, Benjamin and Thaler, Jesse",

--- a/omnifold.py
+++ b/omnifold.py
@@ -4,9 +4,17 @@ import tensorflow.keras.backend as K
 from sklearn.model_selection import train_test_split
 
 def reweight(events,model,batch_size=10000):
-    f = model.predict(events, batch_size=batch_size)
+    f = np.asarray(model.predict(events, batch_size=batch_size))
+
+    # Avoid singular odds ratios when the classifier saturates at 0 or 1.
+    eps = 1e-6
+    f = np.clip(f, eps, 1. - eps)
+
     weights = f / (1. - f)
-    return np.squeeze(np.nan_to_num(weights))
+    if not np.all(np.isfinite(weights)):
+        raise ValueError("Non-finite OmniFold weights encountered after clipping classifier outputs.")
+
+    return np.squeeze(weights)
 
 # Binary crossentropy for classifying two samples with weights
 # Weights are "hidden" by zipping in y_true (the labels)


### PR DESCRIPTION
## Fix numerical instability in reweighting step

### Problem

The reweighting step computes:

    weights = f / (1 - f)

where `f` is the classifier output.

If the classifier saturates to 0 or 1 (which can occur in practice), this leads to:
- division by zero
- infinite weights
- NaNs or extremely large values

Previously, this was silently masked using `np.nan_to_num`, which can hide instability and propagate incorrect weights into later iterations.

---

### Solution

- Clamp classifier outputs before computing the ratio:
  ```python
  eps = 1e-6
  f = np.clip(f, eps, 1 - eps)
  weights = f / (1 - f)