### PR TITLE
Make OmniFold stateless, fix Keras weight handling, and correct fake-event training logic

### DIFF
--- a/GaussianExample_minimal.ipynb
+++ b/GaussianExample_minimal.ipynb
@@ -53,6 +53,9 @@
    },
    "outputs": [],
    "source": [
+    "np.random.seed(1)\n",
+    "tf.random.set_seed(1)\n",
+    "\n",
     "N = 10**5\n",
     "\n",
     "#Synthetic\n",
@@ -148,7 +151,7 @@
     }
    ],
    "source": [
-    "myweights = of.omnifold(theta0,theta_unknown_S,2,model)"
+    "myweights = of.omnifold(theta0,theta_unknown_S,2,model,random_state=1)"
    ]
   },
   {
@@ -183,7 +186,7 @@
    "source": [
     "_,_,_=plt.hist(theta0_G,bins=np.linspace(-3,3,20),color='blue',alpha=0.5,label=\"MC, true\")\n",
     "_,_,_=plt.hist(theta_unknown_G,bins=np.linspace(-3,3,20),color='orange',alpha=0.5,label=\"Data, true\")\n",
-    "_,_,_=plt.hist(theta0_G,weights=myweights[-1, 0, :], bins=np.linspace(-3,3,20),color='black',histtype=\"step\",label=\"OmniFolded\",lw=\"2\")\n",
+    "_,_,_=plt.hist(theta0_G,weights=myweights[-1, 1, :], bins=np.linspace(-3,3,20),color='black',histtype=\"step\",label=\"OmniFolded\",lw=\"2\")\n",
     "plt.xlabel(\"x\")\n",
     "plt.ylabel(\"events\")\n",
     "plt.legend(frameon=False)"

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # <img src="img/omnifold_logo.png" width="100"> OmniFold
 
-This repository contains simple examples of implementing the OmniFold algorithm originally described in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001), [1911.09107 [hep-ph]](https://arxiv.org/abs/1911.09107).  The code for the original paper can be found at [this repository](https://github.com/ericmetodiev/OmniFold), which includes a [binder demo](https://mybinder.org/v2/gh/ericmetodiev/OmniFold/master).  This repository includes simple examples that do not depend on the [energyflow package](https://energyflow.network).
+This repository contains simple examples of implementing the OmniFold algorithm originally described in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001), [1911.09107 [hep-ph]](https://arxiv.org/abs/1911.09107). The code for the original paper can be found at [this repository](https://github.com/ericmetodiev/OmniFold), which includes a [binder demo](https://mybinder.org/v2/gh/ericmetodiev/OmniFold/master). This repository includes simple examples that do not depend on the [energyflow package](https://energyflow.network).
 
 The main example is in the notebook `GaussianExample.ipynb` which performs all four functions of a complete unfolding algorithm:
 
-1. **Background subtraction**. In many cases, one has an estimate of a background process that you would like to remove before correcting for detector effects.  For example, you may want to measure spectra in top quark pair production, but want to subtract the contribution from W+jets.  In the notebook, this is controlled by `back` which is set to 0.1 as a default. Unbinned subtraction is achieved using [neural positive reweighting](https://arxiv.org/abs/2007.11586).
-2. **Fake factors**.  Events that pass the detector-level event selection, but not the particle-level one.  These events participate in Step 1 of OmniFold, but not Step 2.  The rate of these events are controlled by `fake` which is set to 0.1 by default.  You should also change `dummyval` to be some value that is unlikely to occur (set to -10 by default).
-3. **Resolution effects**.  This step does most of the heavy lifting in OmniFold and is the main part of the algorithm.  The procedure is iterative, with the number of iterations set by `iterations`.
-4. **Efficiency factors**.  Events that pass the particle-level event selection, but not the particle-level one.  One option for these events is to simply take the prior, which is the option `weights_pull[theta0_S==dummyval] = 1.` in the code.  Another option (which is on by default) is to set the pulled-back weights for such events to be equal to the average weight: _w = E[w(reco)|true]_.  This also uses the [neural positive reweighting](https://arxiv.org/abs/2007.11586).
+1. **Background subtraction**. In many cases, one has an estimate of a background process that you would like to remove before correcting for detector effects. For example, you may want to measure spectra in top quark pair production, but want to subtract the contribution from W+jets. In the notebook, this is controlled by `back` which is set to 0.1 as a default. Unbinned subtraction is achieved using [neural positive reweighting](https://arxiv.org/abs/2007.11586).
+2. **Fake factors**. Events that pass the detector-level event selection, but not the particle-level one. These events participate in Step 1 of OmniFold, but not Step 2. The rate of these events are controlled by `fake` which is set to 0.1 by default. You should also change `dummyval` to be some value that is unlikely to occur (set to -10 by default).
+3. **Resolution effects**. This step does most of the heavy lifting in OmniFold and is the main part of the algorithm. The procedure is iterative, with the number of iterations set by `iterations`.
+4. **Efficiency factors**. Events that pass the particle-level event selection, but not the detector-level one. One option for these events is to simply take the prior, which is the option `weights_pull[theta0_S==dummyval] = 1.` in the code. Another option (which is on by default) is to set the pulled-back weights for such events to be equal to the average weight: _w = E[w(reco)|true]_. This also uses the [neural positive reweighting](https://arxiv.org/abs/2007.11586).
 
-If you are not worried about (1), (2), or (4) and would simply like to do deconvolution, then you can see the script `GaussianExample_mimimal.ipynb` which calls the OmniFold algorithm in `omnifold.py`.  The Jupyter notebook is simply used to show the results - all that you need to do are specify a TensorFlow model and pass in the data to `omnifold.omnifold`.
+If you are not worried about (1), (2), or (4) and would simply like to do deconvolution, then you can see the script `GaussianExample_mimimal.ipynb` which calls the OmniFold algorithm in `omnifold.py`. The Jupyter notebook is simply used to show the results - all that you need to do are specify a TensorFlow model and pass in the data to `omnifold.omnifold`.
 
 ### Further explanation
 
@@ -27,21 +27,24 @@ Here are some recent presentations that further explain the OmniFold approach:
 
 ### Name
 
-The name OmniFold refers generally to the iterative reweighting algorithm introduced in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001).  One- and multi-dimensional variants are sometimes called Unifold and Multifold, respectively.  The name OmniFold originates from a poem by Emily Dickinson:
+The name OmniFold refers generally to the iterative reweighting algorithm introduced in [Phys. Rev. Lett. 124 (2020) 182001](https://dx.doi.org/10.1103/PhysRevLett.124.182001). One- and multi-dimensional variants are sometimes called Unifold and Multifold, respectively. The name OmniFold originates from a poem by Emily Dickinson:
 
-Emily Dickinson, \#975  
->The Mountain sat upon the Plain  
->In his tremendous Chair&mdash;  
->His observation omnifold,  
->His inquest, everywhere&mdash;  
->  
->The Seasons played around his knees  
->Like Children round a sire&mdash;  
->Grandfather of the Days is He  
->Of Dawn, the Ancestor&mdash;  
+Emily Dickinson, \#975
+
+> The Mountain sat upon the Plain  
+> In his tremendous Chair&mdash;  
+> His observation omnifold,  
+> His inquest, everywhere&mdash;
+>
+> The Seasons played around his knees  
+> Like Children round a sire&mdash;  
+> Grandfather of the Days is He  
+> Of Dawn, the Ancestor&mdash;
 
 ### Citation
+
 If you use OmniFold, please cite:
+
 ```
 @article{Andreassen:2019cjw,
     author = "Andreassen, Anders and Komiske, Patrick T. and Metodiev, Eric M. and Nachman, Benjamin and Thaler, Jesse",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ The main example is in the notebook `GaussianExample.ipynb` which performs all f
 3. **Resolution effects**. This step does most of the heavy lifting in OmniFold and is the main part of the algorithm. The procedure is iterative, with the number of iterations set by `iterations`.
 4. **Efficiency factors**. Events that pass the particle-level event selection, but not the detector-level one. One option for these events is to simply take the prior, which is the option `weights_pull[theta0_S==dummyval] = 1.` in the code. Another option (which is on by default) is to set the pulled-back weights for such events to be equal to the average weight: _w = E[w(reco)|true]_. This also uses the [neural positive reweighting](https://arxiv.org/abs/2007.11586).
 
-If you are not worried about (1), (2), or (4) and would simply like to do deconvolution, then you can see the script `GaussianExample_mimimal.ipynb` which calls the OmniFold algorithm in `omnifold.py`. The Jupyter notebook is simply used to show the results - all that you need to do are specify a TensorFlow model and pass in the data to `omnifold.omnifold`.
+If you are not worried about (1), (2), or (4) and would simply like to do deconvolution, then you can see the script `GaussianExample_minimal.ipynb` which calls the OmniFold algorithm in `omnifold.py`. The Jupyter notebook is simply used to show the results - all that you need to do are specify a TensorFlow model and pass in the data to `omnifold.omnifold`.
+
+The core `omnifold.omnifold` API clones the provided TensorFlow model internally, so the caller's model is not mutated across iterations or repeated runs. Missing particle-level or detector-level events should be passed through the optional `pass_truth` and `pass_reco` masks rather than encoded with sentinel feature values.
 
 ### Further explanation
 

--- a/omnifold.py
+++ b/omnifold.py
@@ -4,9 +4,17 @@ import tensorflow.keras.backend as K
 from sklearn.model_selection import train_test_split
 
 def reweight(events,model,batch_size=10000):
-    f = model.predict(events, batch_size=batch_size)
+    f = np.asarray(model.predict(events, batch_size=batch_size))
+
+    # Avoid singular odds ratios when the classifier saturates at 0 or 1.
+    eps = 1e-6
+    f = np.clip(f, eps, 1. - eps)
+
     weights = f / (1. - f)
-    return np.squeeze(np.nan_to_num(weights))
+    if not np.all(np.isfinite(weights)):
+        raise ValueError("Non-finite OmniFold weights encountered after clipping classifier outputs.")
+
+    return np.squeeze(weights)
 
 # Binary crossentropy for classifying two samples with weights
 # Weights are "hidden" by zipping in y_true (the labels)

--- a/omnifold.py
+++ b/omnifold.py
@@ -1,122 +1,270 @@
+import warnings
+
 import numpy as np
 import tensorflow as tf
-import tensorflow.keras.backend as K
 from sklearn.model_selection import train_test_split
 
-def reweight(events,model,batch_size=10000):
-    f = np.asarray(model.predict(events, batch_size=batch_size))
 
-    # Avoid singular odds ratios when the classifier saturates at 0 or 1.
-    eps = 1e-6
-    f = np.clip(f, eps, 1. - eps)
+DEFAULT_EPS = 1e-6
+DEFAULT_CLIP_WARNING_THRESHOLD = 0.01
+DEFAULT_FILTER_WARNING_THRESHOLD = 0.2
 
-    weights = f / (1. - f)
+
+def _as_model_input(events):
+    events = np.asarray(events)
+    if events.ndim == 1:
+        return events.reshape(-1, 1)
+    return events
+
+
+def _as_boolean_mask(mask, length, name):
+    if mask is None:
+        return np.ones(length, dtype=bool)
+
+    mask = np.asarray(mask, dtype=bool)
+    if mask.shape != (length,):
+        raise ValueError(f"{name} must have shape ({length},), received {mask.shape}.")
+    return mask
+
+
+def _assert_finite_weights(weights, name):
     if not np.all(np.isfinite(weights)):
-        raise ValueError("Non-finite OmniFold weights encountered after clipping classifier outputs.")
+        raise ValueError(f"Non-finite weights encountered in {name}.")
 
+
+def _warn_if_many_filtered(mask, name, threshold):
+    removed_fraction = 1.0 - np.mean(mask.astype(np.float64))
+    if removed_fraction >= threshold:
+        warnings.warn(
+            f"{name} removed {removed_fraction:.1%} of events via masking.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+
+def _clone_optimizer(model):
+    optimizer = getattr(model, "optimizer", None)
+    if optimizer is None:
+        return tf.keras.optimizers.Adam()
+    return tf.keras.optimizers.deserialize(tf.keras.optimizers.serialize(optimizer))
+
+
+def _step_seed(random_state, iteration, step):
+    if random_state is None:
+        return None
+    return int(random_state) + (2 * iteration) + step
+
+
+def clone_model_with_weights(model):
+    """Clone a Keras model and copy its current weights without mutating the input model."""
+
+    cloned_model = tf.keras.models.clone_model(model)
+    cloned_model.set_weights(model.get_weights())
+    return cloned_model
+
+
+def _fit_classifier(
+    reference_model,
+    features,
+    labels,
+    sample_weight,
+    *,
+    batch_size,
+    epochs,
+    validation_fraction,
+    verbose,
+    random_state,
+):
+    """Fit a fresh clone of the reference model using standard labels and sample weights."""
+
+    features = _as_model_input(features)
+    labels = np.asarray(labels, dtype=np.float32)
+    sample_weight = np.asarray(sample_weight, dtype=np.float64)
+
+    if len(features) != len(labels) or len(labels) != len(sample_weight):
+        raise ValueError("Features, labels, and sample weights must have the same length.")
+
+    if len(np.unique(labels)) != 2:
+        raise ValueError("Each OmniFold classifier step requires both binary classes to be present.")
+
+    if random_state is not None:
+        tf.keras.utils.set_random_seed(int(random_state))
+
+    model = clone_model_with_weights(reference_model)
+    model.compile(loss="binary_crossentropy", optimizer=_clone_optimizer(reference_model), metrics=["accuracy"])
+
+    fit_kwargs = {
+        "epochs": epochs,
+        "batch_size": min(batch_size, len(features)),
+        "verbose": verbose,
+        "shuffle": False,
+    }
+
+    if validation_fraction:
+        split_kwargs = {"test_size": validation_fraction, "random_state": random_state}
+        unique_labels, counts = np.unique(labels, return_counts=True)
+        if len(unique_labels) == 2 and np.all(counts >= 2):
+            split_kwargs["stratify"] = labels
+
+        split = train_test_split(features, labels, sample_weight, **split_kwargs)
+        X_train, X_test, Y_train, Y_test, w_train, w_test = split
+        history = model.fit(
+            X_train,
+            Y_train,
+            sample_weight=w_train,
+            validation_data=(X_test, Y_test, w_test),
+            **fit_kwargs,
+        )
+    else:
+        history = model.fit(features, labels, sample_weight=sample_weight, **fit_kwargs)
+
+    return model, history
+
+
+def reweight(
+    events,
+    model,
+    batch_size=10000,
+    *,
+    eps=DEFAULT_EPS,
+    clip_warning_threshold=DEFAULT_CLIP_WARNING_THRESHOLD,
+):
+    """Compute finite density-ratio weights from classifier probabilities."""
+
+    events = _as_model_input(events)
+    f = np.asarray(model.predict(events, batch_size=batch_size, verbose=0), dtype=np.float64)
+
+    clipped = (f <= eps) | (f >= 1.0 - eps)
+    clipped_fraction = np.mean(clipped.astype(np.float64))
+    if clipped_fraction >= clip_warning_threshold:
+        warnings.warn(
+            f"Classifier output clipping affected {clipped_fraction:.1%} of events in reweight().",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+
+    f = np.clip(f, eps, 1.0 - eps)
+    weights = f / (1.0 - f)
+    _assert_finite_weights(weights, "reweight()")
     return np.squeeze(weights)
 
-# Binary crossentropy for classifying two samples with weights
-# Weights are "hidden" by zipping in y_true (the labels)
 
-def weighted_binary_crossentropy(y_true, y_pred):
-    weights = tf.gather(y_true, [1], axis=1) # event weights
-    y_true = tf.gather(y_true, [0], axis=1) # actual y_true for loss
+def omnifold(
+    theta0,
+    theta_unknown_S,
+    iterations,
+    model,
+    verbose=0,
+    *,
+    pass_truth=None,
+    pass_reco=None,
+    random_state=None,
+    epochs=20,
+    step1_batch_size=10000,
+    step2_batch_size=2000,
+    validation_fraction=0.25,
+    clip_warning_threshold=DEFAULT_CLIP_WARNING_THRESHOLD,
+    filter_warning_threshold=DEFAULT_FILTER_WARNING_THRESHOLD,
+):
+    """Run OmniFold without mutating the input model.
 
-    # Clip the prediction value to prevent NaN's and Inf's
-    epsilon = K.epsilon()
-    y_pred = K.clip(y_pred, epsilon, 1. - epsilon)
+    The provided `model` is treated as a template: each Step 1 and Step 2 classifier
+    starts from identical cloned weights. Missing truth/reco information is handled via
+    explicit `pass_truth` and `pass_reco` masks rather than sentinel feature values.
+    Events masked out of a step keep the prior weight of 1 for that step.
+    """
 
-    t_loss = -weights * ((y_true) * K.log(y_pred) +
-                         (1 - y_true) * K.log(1 - y_pred))
+    theta0 = np.asarray(theta0)
+    theta_unknown_S = _as_model_input(theta_unknown_S)
 
-    return K.mean(t_loss)
+    if theta0.ndim < 2 or theta0.shape[1] != 2:
+        raise ValueError("theta0 must have shape (n_events, 2, ...) with generator and detector views.")
 
-def omnifold(theta0,theta_unknown_S,iterations,model,verbose=0):
+    n_events = len(theta0)
+    theta0_G = _as_model_input(theta0[:, 0])
+    theta0_S = _as_model_input(theta0[:, 1])
 
-    weights = np.empty(shape=(iterations, 2, len(theta0)))
-    # shape = (iteration, step, event)
+    pass_truth = _as_boolean_mask(pass_truth, n_events, "pass_truth")
+    pass_reco = _as_boolean_mask(pass_reco, n_events, "pass_reco")
 
-    theta0_G = theta0[:,0]
-    theta0_S = theta0[:,1]
+    if not np.any(pass_truth):
+        raise ValueError("At least one event must pass the truth-level mask.")
+    if not np.any(pass_reco):
+        raise ValueError("At least one event must pass the reco-level mask.")
+    if len(theta_unknown_S) == 0:
+        raise ValueError("theta_unknown_S must contain at least one detector-level event.")
 
-    labels0 = np.zeros(len(theta0))
-    labels_unknown = np.ones(len(theta_unknown_S))
-    labels_unknown_step2 = np.ones(len(theta0_G))
+    _warn_if_many_filtered(pass_reco, "Step 1 reco masking", filter_warning_threshold)
+    _warn_if_many_filtered(pass_truth, "Step 2 truth masking", filter_warning_threshold)
 
-    xvals_1 = np.concatenate((theta0_S, theta_unknown_S))
-    yvals_1 = np.concatenate((labels0, labels_unknown))
+    weights = np.empty(shape=(iterations, 2, n_events), dtype=np.float64)
 
-    xvals_2 = np.concatenate((theta0_G, theta0_G))
-    yvals_2 = np.concatenate((labels0, labels_unknown_step2))
+    weights_pull = np.ones(n_events, dtype=np.float64)
+    weights_push = np.ones(n_events, dtype=np.float64)
 
-    # initial iterative weights are ones
-    weights_pull = np.ones(len(theta0_S))
-    weights_push = np.ones(len(theta0_S))
+    labels0_step1 = np.zeros(np.count_nonzero(pass_reco), dtype=np.float32)
+    labels_unknown_step1 = np.ones(len(theta_unknown_S), dtype=np.float32)
+    labels0_step2 = np.zeros(np.count_nonzero(pass_truth), dtype=np.float32)
+    labels_unknown_step2 = np.ones(np.count_nonzero(pass_truth), dtype=np.float32)
 
     for i in range(iterations):
-
-        if (verbose>0):
+        if verbose > 0:
             print("\nITERATION: {}\n".format(i + 1))
-            pass
-
-        # STEP 1: classify Sim. (which is reweighted by weights_push) to Data
-        # weights reweighted Sim. --> Data
-
-        if (verbose>0):
             print("STEP 1\n")
-            pass
 
-        weights_1 = np.concatenate((weights_push, np.ones(len(theta_unknown_S))))
+        xvals_1 = np.concatenate((theta0_S[pass_reco], theta_unknown_S), axis=0)
+        yvals_1 = np.concatenate((labels0_step1, labels_unknown_step1), axis=0)
+        weights_1 = np.concatenate((weights_push[pass_reco], np.ones(len(theta_unknown_S))), axis=0)
 
-        X_train_1, X_test_1, Y_train_1, Y_test_1, w_train_1, w_test_1 = train_test_split(xvals_1, yvals_1, weights_1)
+        model_step1, _ = _fit_classifier(
+            model,
+            xvals_1,
+            yvals_1,
+            weights_1,
+            batch_size=step1_batch_size,
+            epochs=epochs,
+            validation_fraction=validation_fraction,
+            verbose=verbose,
+            random_state=_step_seed(random_state, i, 0),
+        )
 
-        # zip ("hide") the weights with the labels
-        Y_train_1 = np.stack((Y_train_1, w_train_1), axis=1)
-        Y_test_1 = np.stack((Y_test_1, w_test_1), axis=1)   
+        weights_pull = np.ones(n_events, dtype=np.float64)
+        weights_pull[pass_reco] = weights_push[pass_reco] * reweight(
+            theta0_S[pass_reco],
+            model_step1,
+            batch_size=step1_batch_size,
+            clip_warning_threshold=clip_warning_threshold,
+        )
+        _assert_finite_weights(weights_pull, f"weights_pull at iteration {i + 1}")
+        weights[i, 0, :] = weights_pull
 
-        model.compile(loss=weighted_binary_crossentropy,
-                      optimizer='Adam',
-                      metrics=['accuracy'])
-
-        model.fit(X_train_1,
-                  Y_train_1,
-                  epochs=20,
-                  batch_size=10000,
-                  validation_data=(X_test_1, Y_test_1),
-                  verbose=verbose)
-
-        weights_pull = weights_push * reweight(theta0_S,model)
-        weights[i, :1, :] = weights_pull
-
-        # STEP 2: classify Gen. to reweighted Gen. (which is reweighted by weights_pull)
-        # weights Gen. --> reweighted Gen.
-
-        if (verbose>0):
+        if verbose > 0:
             print("\nSTEP 2\n")
-            pass
 
-        weights_2 = np.concatenate((np.ones(len(theta0_G)), weights_pull))
-        # ones for Gen. (not MC weights), actual weights for (reweighted) Gen.
+        xvals_2 = np.concatenate((theta0_G[pass_truth], theta0_G[pass_truth]), axis=0)
+        yvals_2 = np.concatenate((labels0_step2, labels_unknown_step2), axis=0)
+        weights_2 = np.concatenate((np.ones(np.count_nonzero(pass_truth)), weights_pull[pass_truth]), axis=0)
 
-        X_train_2, X_test_2, Y_train_2, Y_test_2, w_train_2, w_test_2 = train_test_split(xvals_2, yvals_2, weights_2)
+        model_step2, _ = _fit_classifier(
+            model,
+            xvals_2,
+            yvals_2,
+            weights_2,
+            batch_size=step2_batch_size,
+            epochs=epochs,
+            validation_fraction=validation_fraction,
+            verbose=verbose,
+            random_state=_step_seed(random_state, i, 1),
+        )
 
-        # zip ("hide") the weights with the labels
-        Y_train_2 = np.stack((Y_train_2, w_train_2), axis=1)
-        Y_test_2 = np.stack((Y_test_2, w_test_2), axis=1)   
-
-        model.compile(loss=weighted_binary_crossentropy,
-                      optimizer='Adam',
-                      metrics=['accuracy'])
-        model.fit(X_train_2,
-                  Y_train_2,
-                  epochs=20,
-                  batch_size=2000,
-                  validation_data=(X_test_2, Y_test_2),
-                  verbose=verbose)
-
-        weights_push = reweight(theta0_G,model)
-        weights[i, 1:2, :] = weights_push
-        pass
+        weights_push = np.ones(n_events, dtype=np.float64)
+        weights_push[pass_truth] = reweight(
+            theta0_G[pass_truth],
+            model_step2,
+            batch_size=step2_batch_size,
+            clip_warning_threshold=clip_warning_threshold,
+        )
+        _assert_finite_weights(weights_push, f"weights_push at iteration {i + 1}")
+        weights[i, 1, :] = weights_push
 
     return weights

--- a/tests/test_omnifold.py
+++ b/tests/test_omnifold.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+import tensorflow as tf
+from keras.layers import Dense, Input, Lambda
+from keras.models import Model
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import omnifold as of
+
+
+def _build_model(seed=123):
+    tf.keras.utils.set_random_seed(seed)
+    inputs = Input((1,))
+    hidden = Dense(8, activation="relu")(inputs)
+    outputs = Dense(1, activation="sigmoid")(hidden)
+    return Model(inputs=inputs, outputs=outputs)
+
+
+def _make_dataset(n_events=128, seed=7):
+    rng = np.random.default_rng(seed)
+
+    theta0_G = rng.normal(0.2, 0.8, n_events)
+    theta0_S = theta0_G + rng.normal(0.0, 0.5, n_events)
+    theta_unknown_G = rng.normal(0.0, 1.0, n_events)
+    theta_unknown_S = theta_unknown_G + rng.normal(0.0, 0.5, n_events)
+
+    theta0 = np.stack([theta0_G, theta0_S], axis=1)
+    return theta0, theta_unknown_S
+
+
+def test_reweight_clips_saturated_predictions():
+    inputs = Input((1,))
+    outputs = Lambda(lambda x: tf.constant([[0.0], [1.0], [0.5]], dtype=tf.float32))(inputs)
+    model = Model(inputs=inputs, outputs=outputs)
+
+    weights = of.reweight(np.array([0.0, 1.0, 2.0], dtype=np.float32), model)
+
+    assert np.all(np.isfinite(weights))
+    assert weights[0] > 0.0
+    assert weights[1] < 1e7
+    np.testing.assert_allclose(weights[2], 1.0, rtol=1e-6, atol=1e-6)
+
+
+def test_fit_classifier_uses_sample_weight_and_reports_valid_accuracy():
+    model = _build_model(seed=321)
+    features = np.array([-2.0, -1.0, 1.0, 2.0], dtype=np.float32)
+    labels = np.array([0.0, 0.0, 1.0, 1.0], dtype=np.float32)
+    sample_weight = np.array([1.0, 2.0, 1.0, 2.0], dtype=np.float64)
+
+    trained_model, history = of._fit_classifier(
+        model,
+        features,
+        labels,
+        sample_weight,
+        batch_size=2,
+        epochs=1,
+        validation_fraction=0.5,
+        verbose=0,
+        random_state=5,
+    )
+
+    assert "accuracy" in history.history
+    assert "val_accuracy" in history.history
+    assert all(0.0 <= value <= 1.0 for value in history.history["accuracy"])
+    assert all(0.0 <= value <= 1.0 for value in history.history["val_accuracy"])
+    assert trained_model.predict(features.reshape(-1, 1), verbose=0).shape == (4, 1)
+
+
+def test_omnifold_is_reproducible_and_does_not_mutate_input_model():
+    theta0, theta_unknown_S = _make_dataset()
+    model = _build_model(seed=11)
+    original_weights = [weight.copy() for weight in model.get_weights()]
+
+    weights_one = of.omnifold(
+        theta0,
+        theta_unknown_S,
+        2,
+        model,
+        random_state=23,
+        epochs=2,
+        step1_batch_size=64,
+        step2_batch_size=64,
+    )
+    weights_two = of.omnifold(
+        theta0,
+        theta_unknown_S,
+        2,
+        model,
+        random_state=23,
+        epochs=2,
+        step1_batch_size=64,
+        step2_batch_size=64,
+    )
+
+    np.testing.assert_allclose(weights_one, weights_two, rtol=1e-6, atol=1e-6)
+    assert np.all(np.isfinite(weights_one))
+
+    for before, after in zip(original_weights, model.get_weights()):
+        np.testing.assert_allclose(before, after, rtol=1e-7, atol=1e-7)
+
+
+def test_fake_events_are_excluded_from_step2_updates():
+    theta0, theta_unknown_S = _make_dataset(n_events=96, seed=17)
+    pass_truth = np.ones(len(theta0), dtype=bool)
+    pass_reco = np.ones(len(theta0), dtype=bool)
+    fake_indices = np.array([0, 1, 2, 3, 4, 5])
+    pass_truth[fake_indices] = False
+
+    weights = of.omnifold(
+        theta0,
+        theta_unknown_S,
+        2,
+        _build_model(seed=19),
+        pass_truth=pass_truth,
+        pass_reco=pass_reco,
+        random_state=29,
+        epochs=2,
+        step1_batch_size=64,
+        step2_batch_size=64,
+    )
+
+    np.testing.assert_allclose(weights[-1, 1, fake_indices], np.ones(len(fake_indices)))
+    assert np.all(np.isfinite(weights))


### PR DESCRIPTION
## About PR

This PR introduces a structural refactor of the OmniFold training loop to improve correctness, reproducibility, and compatibility with standard ML tooling.

It addresses multiple silent failure modes and API misuses in the current implementation.

---

## Key Changes

### 1. Stateless training (fixes hidden model mutation)

- Each Step 1 and Step 2 now trains a fresh model instance using:
  - `clone_model_with_weights(...)`
- Prevents path-dependent results caused by warm-starting across steps
- Ensures reproducibility across runs

---

### 2. Correct Keras API usage

- Removed packing of event weights into `y_true`
- Now uses:
  - `y_true`: binary labels
  - `sample_weight`: event weights
- Restores correct metric computation (`accuracy`, etc.)
- Improves compatibility with callbacks and tooling

---

### 3. Proper fake-event handling (removes sentinel misuse)

- Replaced `dummyval` approach with explicit masks:
  - `pass_truth`
  - `pass_reco`
- Fake events are now excluded from Step 2 as intended
- Avoids learning artificial sentinel values

---

### 4. Numerical safety improvements

- Enforced clipping before density ratio computation
- Added:
  - `np.isfinite` checks on weights
  - warnings when clipping is triggered frequently

---

### 5. Example and API corrections

- Fixed minimal example to use Step 2 weights (correct output)
- Added fixed seed for reproducibility

---

### 6. Tests

Added regression tests covering:
- reproducibility across runs
- correctness of weight handling
- absence of NaNs / infs
- clipping behavior under saturation

All tests pass:
pytest -q

---


## Potential follow-ups

- log-space density ratio computation for further stability
- calibrated classifiers (Platt scaling / temperature scaling)