### PR TITLE
Improve publication package validation, reliability, and test coverage

### DIFF
--- a/omnifold_publication/__init__.py
+++ b/omnifold_publication/__init__.py
@@ -1,0 +1,45 @@
+"""OmniFold publication package helpers."""
+
+from .exceptions import (
+    OmniFoldPublicationError,
+    PackageReadError,
+    PackageValidationError,
+    PackageWriteError,
+    UnsupportedFormatVersion,
+)
+from .reader import (
+    OmniFoldPackage,
+    get_uncertainty,
+    get_weights,
+    list_systematics,
+    load_events,
+    load_metadata,
+    load_package,
+)
+from .validation import (
+    closure_test,
+    ensure_valid_package,
+    validate_normalization,
+    validate_package,
+)
+from .writer import write_package
+
+__all__ = [
+    "OmniFoldPackage",
+    "OmniFoldPublicationError",
+    "PackageReadError",
+    "PackageValidationError",
+    "PackageWriteError",
+    "UnsupportedFormatVersion",
+    "closure_test",
+    "ensure_valid_package",
+    "get_uncertainty",
+    "get_weights",
+    "list_systematics",
+    "load_events",
+    "load_metadata",
+    "load_package",
+    "validate_normalization",
+    "validate_package",
+    "write_package",
+]

--- a/omnifold_publication/exceptions.py
+++ b/omnifold_publication/exceptions.py
@@ -1,0 +1,21 @@
+"""Custom exceptions for the OmniFold publication package."""
+
+
+class OmniFoldPublicationError(Exception):
+    """Base exception for all omnifold_publication errors."""
+
+
+class PackageWriteError(OmniFoldPublicationError):
+    """Raised when writing a publication package fails."""
+
+
+class PackageReadError(OmniFoldPublicationError):
+    """Raised when reading a publication package fails."""
+
+
+class PackageValidationError(OmniFoldPublicationError):
+    """Raised when a publication package fails validation."""
+
+
+class UnsupportedFormatVersion(OmniFoldPublicationError):
+    """Raised when a package uses an unsupported format_version."""

--- a/omnifold_publication/reader.py
+++ b/omnifold_publication/reader.py
@@ -1,0 +1,276 @@
+"""Read the OmniFold publication package."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import yaml
+
+from .exceptions import PackageReadError, UnsupportedFormatVersion
+
+
+SUPPORTED_FORMAT_VERSIONS = {"0.1", "0.2"}
+DEFAULT_HDF_KEY = "df"
+
+
+def _resolve_metadata_path(path: str | Path) -> Path:
+    path = Path(path)
+    return path / "metadata.yaml" if path.is_dir() else path
+
+
+def _column_from_spec(spec: Any) -> str:
+    if isinstance(spec, str):
+        return spec
+    if isinstance(spec, dict) and isinstance(spec.get("column"), str):
+        return spec["column"]
+    raise PackageReadError(f"Weight specification does not define a column: {spec!r}")
+
+
+def ensure_supported_format_version(metadata: dict[str, Any]) -> None:
+    """Raise a clear error when package metadata uses an unsupported version."""
+
+    version = metadata.get("format_version")
+    if version not in SUPPORTED_FORMAT_VERSIONS:
+        supported = ", ".join(sorted(SUPPORTED_FORMAT_VERSIONS))
+        raise UnsupportedFormatVersion(
+            f"Unsupported format_version {version!r}; supported versions: {supported}."
+        )
+
+
+def load_metadata(path: str | Path, enforce_version: bool = False) -> dict[str, Any]:
+    """Load package metadata from a package directory or metadata file path."""
+
+    metadata_path = _resolve_metadata_path(path)
+    with metadata_path.open("r", encoding="utf-8") as stream:
+        metadata = yaml.safe_load(stream) or {}
+    if not isinstance(metadata, dict):
+        raise PackageReadError("Package metadata must be a mapping.")
+    if enforce_version:
+        ensure_supported_format_version(metadata)
+    return metadata
+
+
+def _resolve_data_path(base_path: Path, data_path: str) -> Path:
+    data = Path(data_path)
+    if data.is_absolute():
+        return data
+    return base_path / data
+
+
+def load_events(path: str | Path, columns: list[str] | None = None) -> pd.DataFrame:
+    """Load event data declared by metadata or directly from an event file."""
+
+    path = Path(path)
+    if path.is_dir():
+        metadata = load_metadata(path)
+        files = metadata.get("files", {})
+        nominal_file = files.get("nominal", {}) if isinstance(files, dict) else {}
+        if isinstance(nominal_file, dict) and "path" in nominal_file:
+            events_path = _resolve_data_path(path, nominal_file["path"])
+            return pd.read_hdf(events_path, key=DEFAULT_HDF_KEY, columns=columns)
+
+        publication = metadata.get("publication")
+        if not isinstance(publication, dict) or "events_file" not in publication:
+            raise PackageReadError(
+                "Metadata must define either files.nominal.path or "
+                "publication.events_file."
+            )
+        events_file = publication["events_file"]
+        events_path = path / events_file
+        return pd.read_parquet(events_path, columns=columns)
+    else:
+        events_path = path
+        if events_path.suffix in {".h5", ".hdf5"}:
+            return pd.read_hdf(events_path, key=DEFAULT_HDF_KEY, columns=columns)
+        return pd.read_parquet(events_path, columns=columns)
+
+
+def list_systematics(metadata: dict[str, Any]) -> list[str]:
+    """Return systematic variation names declared in package metadata."""
+
+    file_block = metadata.get("files", {})
+    files = file_block.get("systematics", []) if isinstance(file_block, dict) else []
+    if isinstance(files, list) and files:
+        return sorted(
+            Path(systematic["path"]).stem
+            for systematic in files
+            if isinstance(systematic, dict) and "path" in systematic
+        )
+
+    systematics = metadata.get("systematics", {})
+    if isinstance(systematics, dict) and systematics:
+        return sorted(systematics)
+
+    weights = metadata.get("weights", {})
+    if isinstance(weights, dict) and "replica" in weights:
+        return ["replica"]
+    return []
+
+
+def resolve_weight_column(
+    metadata: dict[str, Any],
+    variation: str = "nominal",
+    iteration: int | None = None,
+    step: str | None = None,
+) -> str:
+    """Resolve a metadata-declared weight selection to a concrete column name."""
+
+    weights = metadata.get("weights", {})
+    if not isinstance(weights, dict):
+        raise PackageReadError("Metadata key 'weights' must be a mapping.")
+
+    if iteration is not None or step is not None:
+        if iteration is None or step is None:
+            raise PackageReadError(
+                "Both iteration and step are required for iteration weights."
+            )
+        if step not in {"step1", "step2"}:
+            raise PackageReadError("Iteration step must be 'step1' or 'step2'.")
+        for entry in weights.get("iterations", []):
+            if entry.get("iteration") == iteration and step in entry:
+                return _column_from_spec(entry[step])
+        raise PackageReadError(
+            f"No weight column declared for iteration={iteration}, step={step!r}."
+        )
+
+    if variation == "nominal":
+        if "nominal" not in weights:
+            raise PackageReadError("Metadata does not declare a nominal weight.")
+        return _column_from_spec(weights["nominal"])
+
+    if variation in weights and isinstance(weights[variation], str):
+        return weights[variation]
+
+    raise PackageReadError(f"Unknown metadata-declared weight variation: {variation}")
+
+
+def get_weights(
+    df: pd.DataFrame,
+    metadata: dict[str, Any],
+    variation: str = "nominal",
+    iteration: int | None = None,
+    step: str | None = None,
+):
+    """Return the requested weight array from the loaded event table."""
+
+    column = resolve_weight_column(
+        metadata,
+        variation=variation,
+        iteration=iteration,
+        step=step,
+    )
+    if column not in df.columns:
+        raise PackageReadError(
+            f"Weight column {column!r} is not present in the event table."
+        )
+    return df[column].to_numpy()
+
+
+def get_uncertainty(
+    df: pd.DataFrame,
+    metadata: dict[str, Any],
+    variation: str,
+) -> np.ndarray:
+    """Return per-event absolute difference between a variation and nominal weights."""
+
+    nominal = get_weights(df, metadata, variation="nominal")
+    varied = get_weights(df, metadata, variation=variation)
+    return np.abs(varied - nominal)
+
+
+class OmniFoldPackage:
+    """Thin wrapper matching the proposal-facing package API."""
+
+    def __init__(self, package_dir: str | Path):
+        self.package_dir = Path(package_dir)
+        self._metadata = load_metadata(self.package_dir, enforce_version=True)
+
+    def load_events(self, columns: list[str] | None = None) -> pd.DataFrame:
+        return load_events(self.package_dir, columns=columns)
+
+    def list_systematics(self) -> list[str]:
+        return list_systematics(self._metadata)
+
+    def list_weights(self) -> list[str]:
+        """Return all declared weight variation names."""
+
+        weights = self._metadata.get("weights", {})
+        if not isinstance(weights, dict):
+            return []
+        return [key for key in weights if key != "iterations"]
+
+    def list_observables(self) -> list[str]:
+        """Return all declared observable names."""
+
+        observables = self._metadata.get("observables", [])
+        if not isinstance(observables, list):
+            return []
+        return [
+            observable["name"]
+            for observable in observables
+            if isinstance(observable, dict) and "name" in observable
+        ]
+
+    def summary(self) -> dict[str, Any]:
+        """Return a concise summary of the package contents."""
+
+        publication = self._metadata.get("publication", {})
+        return {
+            "format_version": self._metadata.get("format_version"),
+            "event_count": publication.get("event_count")
+            if isinstance(publication, dict)
+            else None,
+            "observables": self.list_observables(),
+            "weights": self.list_weights(),
+            "systematics": self.list_systematics(),
+            "checksum_sha256": publication.get("checksum_sha256", "not recorded")
+            if isinstance(publication, dict)
+            else "not recorded",
+        }
+
+    def get_weights(
+        self,
+        kind: str = "nominal",
+        variation: str | None = None,
+        iteration: int | None = None,
+        step: str | None = None,
+    ):
+        selection = variation or kind
+        column = resolve_weight_column(
+            self._metadata,
+            variation=selection,
+            iteration=iteration,
+            step=step,
+        )
+        df = self.load_events(columns=[column])
+        return get_weights(
+            df,
+            self._metadata,
+            variation=selection,
+            iteration=iteration,
+            step=step,
+        )
+
+    def get_uncertainty(self, variation: str) -> np.ndarray:
+        nominal_column = resolve_weight_column(self._metadata, variation="nominal")
+        variation_column = resolve_weight_column(self._metadata, variation=variation)
+        columns = list(dict.fromkeys([nominal_column, variation_column]))
+        df = self.load_events(columns=columns)
+        return get_uncertainty(df, self._metadata, variation=variation)
+
+    def metadata(self) -> dict[str, Any]:
+        return self._metadata
+
+    def validate(self) -> None:
+        from .validation import ensure_valid_package
+
+        ensure_valid_package(self.package_dir)
+
+
+def load_package(package_dir: str | Path) -> OmniFoldPackage:
+    """Load a publication package and return the proposal-style wrapper."""
+
+    return OmniFoldPackage(package_dir)

--- a/omnifold_publication/schema.py
+++ b/omnifold_publication/schema.py
@@ -1,0 +1,150 @@
+"""Pydantic v2 schema for OmniFold ``metadata.yaml`` files.
+
+Example:
+    metadata = yaml.safe_load(open("spec/metadata.yaml"))
+    Metadata(**metadata)
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, ValidationError
+
+
+class PhaseSpace(BaseModel):
+    lepton_pt_min: str | float = Field(...)
+    lepton_eta_max: str | float = Field(...)
+    mll_min: str | float = Field(...)
+    mll_max: str | float = Field(...)
+    min_track_jets: str | int = Field(...)
+    note: str | None = Field(default=None)
+
+
+class Observable(BaseModel):
+    name: str = Field(...)
+    description: str = Field(...)
+    units: str = Field(...)
+    suggested_bins: list[int | float] | None = Field(default=None)
+    bins_note: str | None = Field(default=None)
+
+
+class WeightFamily(BaseModel):
+    name: str = Field(...)
+    pattern: str = Field(...)
+    type: str = Field(...)
+    combination: str = Field(...)
+
+
+class Weights(BaseModel):
+    nominal: str = Field(...)
+    base_mc_weight: str = Field(...)
+    bootstrap_prefix: str | None = Field(default=None)
+    ensemble_prefix: str | None = Field(default=None)
+    data_bootstrap_prefix: str | None = Field(default=None)
+    additional_families: list[str] = Field(default_factory=list)
+    notes: list[str] = Field(default_factory=list)
+
+
+class Systematics(BaseModel):
+    expected_families: list[WeightFamily] = Field(default_factory=list)
+
+
+class Normalization(BaseModel):
+    luminosity: str | float | None = Field(default=None)
+    cross_section: str | float | None = Field(default=None)
+    event_weights_normalized: bool | None = Field(default=None)
+    mode: str | None = Field(default=None)
+    base_weight_column: str | None = Field(default=None)
+    nominal_weight_column: str | None = Field(default=None)
+    expected_nominal_sumw: float | None = Field(default=None)
+    tolerance: float | None = Field(default=None)
+    note: str | None = Field(default=None)
+
+
+class EventSelection(BaseModel):
+    description: str = Field(...)
+    inferred_phase_space: str | None = Field(default=None)
+    phase_space: PhaseSpace | None = Field(default=None)
+
+
+class Iterations(BaseModel):
+    supported_steps: list[str] = Field(default_factory=list)
+    note: str | None = Field(default=None)
+
+
+class Training(BaseModel):
+    algorithm: str = Field(...)
+    iterations: str | int = Field(...)
+    architecture: str = Field(...)
+    note: str | None = Field(default=None)
+
+
+class Dataset(BaseModel):
+    name: str = Field(...)
+    experiment: str | None = Field(default=None)
+    description: str | None = Field(default=None)
+    schema_version: str | None = Field(default=None)
+
+
+class Generation(BaseModel):
+    nominal_generator: str = Field(...)
+    alternative_generators: list[str] = Field(default_factory=list)
+    alternative_samples: list[str] = Field(default_factory=list)
+
+
+class FileEntry(BaseModel):
+    filename: str = Field(...)
+    path: str = Field(...)
+    event_count: int = Field(...)
+    note: str | None = Field(default=None)
+
+
+class Files(BaseModel):
+    nominal: FileEntry = Field(...)
+    systematics: list[FileEntry] = Field(default_factory=list)
+
+
+class EventAlignment(BaseModel):
+    method: str = Field(default="row_order")
+    column: str | None = Field(default=None)
+
+
+class Publication(BaseModel):
+    format: str = Field(...)
+    events_file: str = Field(...)
+    event_count: int = Field(...)
+    columns: list[str] = Field(default_factory=list)
+    source_file: str | None = Field(default=None)
+    event_alignment: EventAlignment | None = Field(default=None)
+    checksum_sha256: str | None = Field(default=None)
+
+
+class Metadata(BaseModel):
+    format_version: str = Field(...)
+    dataset: Dataset | None = Field(default=None)
+    generation: Generation | None = Field(default=None)
+    files: Files | None = Field(default=None)
+    observables: list[Observable] = Field(...)
+    weights: Weights = Field(...)
+    systematics: Systematics | None = Field(default=None)
+    iterations: Iterations | None = Field(default=None)
+    normalization: Normalization = Field(...)
+    event_selection: EventSelection | None = Field(default=None)
+    training: Training | None = Field(default=None)
+    publication: Publication | None = Field(default=None)
+    usage_notes: list[str] = Field(default_factory=list)
+
+
+def validate_metadata(metadata: dict) -> None:
+    """Validate metadata and raise a clear ``ValueError`` on schema errors."""
+
+    try:
+        Metadata(**metadata)
+    except ValidationError as exc:
+        errors = []
+        for error in exc.errors():
+            location = ".".join(str(part) for part in error["loc"])
+            errors.append(f"{location}: {error['msg']}")
+        message = "Invalid OmniFold metadata:\n" + "\n".join(
+            f"- {error}" for error in errors
+        )
+        raise ValueError(message) from exc

--- a/omnifold_publication/validation.py
+++ b/omnifold_publication/validation.py
@@ -1,0 +1,310 @@
+"""Validation helpers for the OmniFold publication package."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from .exceptions import PackageReadError, PackageValidationError
+from .reader import (
+    SUPPORTED_FORMAT_VERSIONS,
+    list_systematics,
+    load_metadata,
+    resolve_weight_column,
+)
+from .schema import validate_metadata
+
+
+REQUIRED_PUBLICATION_KEYS = ("format", "events_file", "event_count", "columns")
+
+
+def _weight_columns(metadata: dict[str, Any]) -> list[str]:
+    columns: list[str] = []
+    for variation in ["nominal", *list_systematics(metadata)]:
+        try:
+            columns.append(resolve_weight_column(metadata, variation=variation))
+        except (KeyError, PackageReadError):
+            continue
+
+    weights = metadata.get("weights", {})
+    if isinstance(weights, dict):
+        try:
+            columns.append(resolve_weight_column(metadata, variation="base_mc_weight"))
+        except (KeyError, PackageReadError):
+            base = weights.get("base_mc_weight")
+            if isinstance(base, str):
+                columns.append(base)
+
+        for entry in weights.get("iterations", []):
+            for step in ("step1", "step2"):
+                step_spec = entry.get(step)
+                if isinstance(step_spec, str):
+                    columns.append(step_spec)
+                elif isinstance(step_spec, dict) and isinstance(
+                    step_spec.get("column"), str
+                ):
+                    columns.append(step_spec["column"])
+
+    return list(dict.fromkeys(columns))
+
+
+def _required_columns(metadata: dict[str, Any]) -> set[str]:
+    publication = metadata.get("publication", {})
+    required_columns = set(publication.get("columns", []))
+
+    for observable in metadata.get("observables", []):
+        if isinstance(observable, dict) and "name" in observable:
+            required_columns.add(observable["name"])
+
+    required_columns.update(_weight_columns(metadata))
+
+    alignment = publication.get("event_alignment", {})
+    if isinstance(alignment, dict) and alignment.get("method") == "column":
+        column = alignment.get("column")
+        if isinstance(column, str):
+            required_columns.add(column)
+
+    return required_columns
+
+
+def _validate_format_version(metadata: dict[str, Any]) -> list[str]:
+    version = metadata.get("format_version")
+    if not isinstance(version, str):
+        return ["format_version must be a string, for example '0.2'."]
+    if version not in SUPPORTED_FORMAT_VERSIONS:
+        supported = ", ".join(sorted(SUPPORTED_FORMAT_VERSIONS))
+        return [
+            f"Unsupported format_version {version!r}; supported versions: {supported}."
+        ]
+    return []
+
+
+def validate_event_alignment(df: pd.DataFrame, metadata: dict[str, Any]) -> list[str]:
+    """Validate the event-alignment contract declared by package metadata."""
+
+    publication = metadata.get("publication", {})
+    alignment = publication.get("event_alignment", {"method": "row_order"})
+    if not isinstance(alignment, dict):
+        return ["publication.event_alignment must be a mapping."]
+
+    method = alignment.get("method", "row_order")
+    if method == "row_order":
+        return []
+    if method != "column":
+        return [f"Unsupported event alignment method: {method!r}."]
+
+    column = alignment.get("column")
+    if not isinstance(column, str):
+        return [
+            "Column-based event alignment requires publication.event_alignment.column."
+        ]
+    if column not in df.columns:
+        return [f"Event alignment column {column!r} is missing from events.parquet."]
+
+    errors: list[str] = []
+    if df[column].isna().any():
+        errors.append(f"Event alignment column {column!r} contains null values.")
+    if df[column].duplicated().any():
+        errors.append(f"Event alignment column {column!r} contains duplicate values.")
+    return errors
+
+
+def validate_weight_lengths(df: pd.DataFrame, metadata: dict[str, Any]) -> list[str]:
+    """Check that declared weight columns are present, finite, and row-aligned."""
+
+    errors: list[str] = []
+    event_count = len(df)
+    for column in _weight_columns(metadata):
+        if column not in df.columns:
+            errors.append(
+                f"Declared weight column {column!r} is missing from events.parquet."
+            )
+            continue
+        if len(df[column]) != event_count:
+            errors.append(
+                f"Declared weight column {column!r} has length {len(df[column])}; "
+                f"expected {event_count}."
+            )
+        if not np.isfinite(df[column].to_numpy(dtype=float)).all():
+            errors.append(f"Declared weight column {column!r} contains non-finite values.")
+    return errors
+
+
+def validate_normalization(
+    df: pd.DataFrame,
+    metadata: dict[str, Any],
+) -> list[str]:
+    """Validate normalization metadata against the stored event table."""
+
+    normalization = metadata.get("normalization")
+    if not isinstance(normalization, dict):
+        return []
+
+    column = normalization.get("nominal_weight_column")
+    if not isinstance(column, str):
+        try:
+            column = resolve_weight_column(metadata, variation="nominal")
+        except (KeyError, PackageReadError):
+            return ["normalization.nominal_weight_column is missing."]
+
+    if column not in df.columns:
+        return [f"Normalization weight column {column!r} is missing from events.parquet."]
+
+    weights = df[column].to_numpy(dtype=float)
+    if not np.isfinite(weights).all():
+        return [f"Normalization weight column {column!r} contains non-finite values."]
+
+    errors: list[str] = []
+    expected = normalization.get("expected_nominal_sumw")
+    if expected is not None:
+        actual = float(weights.sum())
+        tolerance = float(normalization.get("tolerance", 1.0e-8))
+        allowed = tolerance * max(1.0, abs(float(expected)))
+        if abs(actual - float(expected)) > allowed:
+            errors.append(
+                "nominal weight sum mismatch: "
+                f"metadata={float(expected):.12g} actual={actual:.12g}"
+            )
+
+    return errors
+
+
+def _verify_checksum(events_path: Path, metadata: dict[str, Any]) -> list[str]:
+    """Verify SHA-256 checksum of events.parquet if recorded in metadata."""
+
+    expected = metadata.get("publication", {}).get("checksum_sha256")
+    if expected is None:
+        return []
+
+    sha256 = hashlib.sha256()
+    with events_path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8192), b""):
+            sha256.update(chunk)
+
+    actual = sha256.hexdigest()
+    if actual != expected:
+        return [
+            "Checksum mismatch for events.parquet: "
+            f"expected {expected}, got {actual}"
+        ]
+    return []
+
+
+def validate_package(path: str | Path) -> list[str]:
+    """Return a list of validation errors for the package at ``path``."""
+
+    package_dir = Path(path)
+    metadata_path = package_dir / "metadata.yaml"
+    errors: list[str] = []
+
+    if not package_dir.exists():
+        return [f"Package directory does not exist: {package_dir}"]
+    if not metadata_path.exists():
+        errors.append(f"Missing metadata file: {metadata_path}")
+    if errors:
+        return errors
+
+    metadata = load_metadata(metadata_path)
+
+    try:
+        validate_metadata(metadata)
+    except ValueError as exc:
+        errors.append(str(exc))
+        return errors
+
+    publication = metadata.get("publication", {})
+
+    for key in REQUIRED_PUBLICATION_KEYS:
+        if key not in publication:
+            errors.append(f"Missing publication key: {key}")
+
+    if errors:
+        return errors
+
+    errors.extend(_validate_format_version(metadata))
+
+    if publication["format"] != "parquet":
+        errors.append("publication.format must be 'parquet'.")
+
+    events_path = package_dir / publication["events_file"]
+    if not events_path.exists():
+        errors.append(f"Missing events file: {events_path}")
+
+    if errors:
+        return errors
+
+    errors.extend(_verify_checksum(events_path, metadata))
+
+    if errors:
+        return errors
+
+    df = pd.read_parquet(events_path)
+    required_columns = _required_columns(metadata)
+
+    missing_columns = sorted(required_columns - set(df.columns))
+    if missing_columns:
+        errors.append(
+            "Missing required columns in events.parquet: "
+            + ", ".join(missing_columns)
+        )
+
+    actual_event_count = int(len(df))
+    if actual_event_count != int(publication["event_count"]):
+        errors.append(
+            "event_count mismatch: "
+            f"metadata={publication['event_count']} actual={actual_event_count}"
+        )
+
+    errors.extend(validate_event_alignment(df, metadata))
+    errors.extend(validate_weight_lengths(df, metadata))
+    errors.extend(validate_normalization(df, metadata))
+
+    return errors
+
+
+def ensure_valid_package(path: str | Path) -> None:
+    """Raise ``PackageValidationError`` if the package is invalid."""
+
+    errors = validate_package(path)
+    if errors:
+        raise PackageValidationError("\n".join(errors))
+
+
+def closure_test(
+    path: str | Path,
+    observable: str,
+    bins: int | np.ndarray = 50,
+    variation: str = "nominal",
+) -> dict[str, Any]:
+    """Compute a simple histogram closure summary for a packaged observable."""
+
+    from .reader import load_package
+
+    package = load_package(path)
+    weights = package.get_weights(variation=variation)
+    df = package.load_events(columns=[observable])
+    if observable not in df.columns:
+        raise PackageValidationError(
+            f"Observable {observable!r} is not present in the event table."
+        )
+
+    hist, edges = np.histogram(
+        df[observable].to_numpy(dtype=float),
+        bins=bins,
+        weights=weights,
+    )
+    sumw = float(weights.sum())
+    hist_sumw = float(hist.sum())
+    denominator = max(1.0, abs(sumw))
+
+    return {
+        "hist": hist,
+        "edges": edges,
+        "sumw": sumw,
+        "hist_sumw": hist_sumw,
+        "relative_difference": abs(hist_sumw - sumw) / denominator,
+    }

--- a/omnifold_publication/writer.py
+++ b/omnifold_publication/writer.py
@@ -1,0 +1,228 @@
+"""Write the OmniFold publication package to Parquet."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import re
+from typing import Any
+
+import pandas as pd
+import yaml
+
+from .exceptions import PackageWriteError
+
+
+DEFAULT_INPUT_PATH = Path("data/multifold.h5")
+DEFAULT_METADATA_SOURCE = Path("spec/metadata.yaml")
+DEFAULT_OUTPUT_DIR = Path("artifacts/demo_nominal")
+DEFAULT_EVENT_COUNT = 10_000
+PRIMARY_OBSERVABLE = "pT_ll"
+EXTRA_OBSERVABLE = "pT_l1"
+EVENT_ID_COLUMN = "event_id"
+BASE_WEIGHT_COLUMN = "weight_mc"
+NOMINAL_WEIGHT_COLUMN = "weights_nominal"
+REPLICA_PREFIXES = ("weights_ensemble_", "weights_bootstrap_mc_")
+FORMAT_VERSION = "0.2"
+
+
+def _compute_checksum(path: Path) -> str:
+    """Compute SHA-256 checksum of a file."""
+
+    sha256 = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(8192), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+
+
+def _load_source_metadata(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as stream:
+        data = yaml.safe_load(stream) or {}
+    if not isinstance(data, dict):
+        raise PackageWriteError("Source metadata must be a mapping.")
+    return data
+
+
+def _find_replica_column(columns: list[str]) -> str | None:
+    for prefix in REPLICA_PREFIXES:
+        for column in columns:
+            if column.startswith(prefix):
+                return column
+    return None
+
+
+def _discover_iteration_weights(columns: list[str]) -> list[dict[str, Any]]:
+    """Find step1/step2 iteration weights when the source file provides them."""
+
+    patterns = (
+        re.compile(r"^weights_(step[12])_(?:iter|iteration)_?(\d+)$"),
+        re.compile(r"^weights_(?:iter|iteration)_?(\d+)_(step[12])$"),
+    )
+    by_iteration: dict[int, dict[str, dict[str, str]]] = {}
+
+    for column in columns:
+        for pattern in patterns:
+            match = pattern.match(column)
+            if match is None:
+                continue
+            first, second = match.groups()
+            if first.startswith("step"):
+                step = first
+                iteration = int(second)
+            else:
+                iteration = int(first)
+                step = second
+            by_iteration.setdefault(iteration, {})[step] = {"column": column}
+            break
+
+    return [
+        {"iteration": iteration, **steps}
+        for iteration, steps in sorted(by_iteration.items())
+    ]
+
+
+def _build_systematics(replica_column: str | None) -> dict[str, dict[str, str]]:
+    if replica_column is None:
+        return {}
+    return {
+        "replica": {
+            "column": replica_column,
+            "type": "ensemble",
+            "combination": "absolute_difference_from_nominal",
+        }
+    }
+
+
+def _filter_observables(
+    source_metadata: dict[str, Any],
+    selected_names: list[str],
+) -> list[dict[str, Any]]:
+    observables = source_metadata.get("observables", [])
+    if not isinstance(observables, list):
+        return [{"name": name} for name in selected_names]
+
+    filtered = [
+        observable
+        for observable in observables
+        if isinstance(observable, dict) and observable.get("name") in selected_names
+    ]
+    if filtered:
+        return filtered
+    return [{"name": name} for name in selected_names]
+
+
+def _build_package_metadata(
+    source_metadata: dict[str, Any],
+    observable_names: list[str],
+    selected_columns: list[str],
+    replica_column: str | None,
+    iteration_weights: list[dict[str, Any]],
+    event_count: int,
+    nominal_sumw: float,
+    input_path: Path,
+    has_event_id: bool,
+) -> dict[str, Any]:
+    weights: dict[str, Any] = {
+        "nominal": NOMINAL_WEIGHT_COLUMN,
+        "base_mc_weight": BASE_WEIGHT_COLUMN,
+    }
+    if replica_column is not None:
+        weights["replica"] = replica_column
+    if iteration_weights:
+        weights["iterations"] = iteration_weights
+
+    metadata: dict[str, Any] = {
+        "format_version": FORMAT_VERSION,
+        "dataset": source_metadata.get("dataset", {}),
+        "observables": _filter_observables(source_metadata, observable_names),
+        "weights": weights,
+        "systematics": _build_systematics(replica_column),
+        "normalization": {
+            "mode": "shape",
+            "base_weight_column": BASE_WEIGHT_COLUMN,
+            "nominal_weight_column": NOMINAL_WEIGHT_COLUMN,
+            "expected_nominal_sumw": nominal_sumw,
+            "tolerance": 1.0e-8,
+        },
+        "publication": {
+            "format": "parquet",
+            "events_file": "events.parquet",
+            "event_count": event_count,
+            "columns": selected_columns,
+            "source_file": input_path.as_posix(),
+            "event_alignment": {
+                "method": "column" if has_event_id else "row_order",
+                "column": EVENT_ID_COLUMN if has_event_id else None,
+            },
+        },
+    }
+    return metadata
+
+
+def write_package(
+    input_path: str | Path = DEFAULT_INPUT_PATH,
+    output_dir: str | Path = DEFAULT_OUTPUT_DIR,
+    metadata_source: str | Path = DEFAULT_METADATA_SOURCE,
+    event_count: int = DEFAULT_EVENT_COUNT,
+    observables: list[str] | None = None,
+) -> Path:
+    """Create a minimal Parquet-backed publication package."""
+
+    input_path = Path(input_path)
+    if not input_path.exists():
+        raise PackageWriteError(
+            f"Input file not found: {input_path}. "
+            f"Make sure data/multifold.h5 is present locally."
+        )
+
+    output_dir = Path(output_dir)
+    metadata_source = Path(metadata_source)
+
+    df = pd.read_hdf(input_path, "df").iloc[:event_count].copy()
+    source_columns = list(df.columns)
+    replica_column = _find_replica_column(source_columns)
+    iteration_weights = _discover_iteration_weights(source_columns)
+
+    observable_names = observables or [PRIMARY_OBSERVABLE, EXTRA_OBSERVABLE]
+    selected_columns = [
+        *observable_names,
+        BASE_WEIGHT_COLUMN,
+        NOMINAL_WEIGHT_COLUMN,
+    ]
+    if EVENT_ID_COLUMN in df.columns:
+        selected_columns.append(EVENT_ID_COLUMN)
+    if replica_column is not None:
+        selected_columns.append(replica_column)
+    for iteration in iteration_weights:
+        for step in ("step1", "step2"):
+            step_spec = iteration.get(step)
+            if isinstance(step_spec, dict):
+                selected_columns.append(step_spec["column"])
+
+    selected_columns = list(dict.fromkeys(selected_columns))
+
+    package_df = df.loc[:, selected_columns]
+    package_event_count = int(len(package_df))
+    nominal_sumw = float(package_df[NOMINAL_WEIGHT_COLUMN].to_numpy(dtype=float).sum())
+    source_metadata = _load_source_metadata(metadata_source)
+    package_metadata = _build_package_metadata(
+        source_metadata=source_metadata,
+        observable_names=observable_names,
+        selected_columns=selected_columns,
+        replica_column=replica_column,
+        iteration_weights=iteration_weights,
+        event_count=package_event_count,
+        nominal_sumw=nominal_sumw,
+        input_path=input_path,
+        has_event_id=EVENT_ID_COLUMN in package_df.columns,
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    events_path = output_dir / "events.parquet"
+    package_df.to_parquet(events_path, index=False)
+    package_metadata["publication"]["checksum_sha256"] = _compute_checksum(events_path)
+    with (output_dir / "metadata.yaml").open("w", encoding="utf-8") as stream:
+        yaml.safe_dump(package_metadata, stream, sort_keys=False)
+
+    return output_dir

--- a/tests/test_checksum.py
+++ b/tests/test_checksum.py
@@ -1,0 +1,83 @@
+"""Tests for checksum verification."""
+
+import hashlib
+
+import pandas as pd
+import yaml
+
+from omnifold_publication.validation import validate_package
+from omnifold_publication.writer import write_package
+
+
+def test_checksum_passes_on_valid_package(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    errors = validate_package(out)
+    assert errors == []
+
+
+def test_checksum_fails_on_tampered_parquet(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    events_path = out / "events.parquet"
+    with events_path.open("ab") as stream:
+        stream.write(b"tampered")
+    errors = validate_package(out)
+    assert any("Checksum mismatch" in error for error in errors)
+
+
+def test_checksum_is_actual_sha256(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    with (out / "metadata.yaml").open("r", encoding="utf-8") as stream:
+        metadata = yaml.safe_load(stream)
+    actual = hashlib.sha256((out / "events.parquet").read_bytes()).hexdigest()
+    assert metadata["publication"]["checksum_sha256"] == actual
+
+
+def test_validation_without_checksum_still_passes(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    metadata_path = out / "metadata.yaml"
+    with metadata_path.open("r", encoding="utf-8") as stream:
+        metadata = yaml.safe_load(stream)
+    metadata["publication"].pop("checksum_sha256")
+    with metadata_path.open("w", encoding="utf-8") as stream:
+        yaml.safe_dump(metadata, stream, sort_keys=False)
+    assert validate_package(out) == []
+
+
+def test_checksum_refresh_allows_other_validation_failures(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    events_path = out / "events.parquet"
+    metadata_path = out / "metadata.yaml"
+
+    df = pd.read_parquet(events_path).drop(columns=["weights_nominal"])
+    df.to_parquet(events_path, index=False)
+
+    with metadata_path.open("r", encoding="utf-8") as stream:
+        metadata = yaml.safe_load(stream)
+    metadata["publication"]["checksum_sha256"] = hashlib.sha256(
+        events_path.read_bytes()
+    ).hexdigest()
+    with metadata_path.open("w", encoding="utf-8") as stream:
+        yaml.safe_dump(metadata, stream, sort_keys=False)
+
+    errors = validate_package(out)
+    assert any("weights_nominal" in error for error in errors)

--- a/tests/test_reader_api.py
+++ b/tests/test_reader_api.py
@@ -1,0 +1,96 @@
+"""Tests for reader API methods and typed exceptions."""
+
+import pytest
+import yaml
+
+from omnifold_publication.exceptions import PackageReadError, UnsupportedFormatVersion
+from omnifold_publication.reader import get_weights, load_metadata, load_package
+from omnifold_publication.writer import write_package
+
+
+def test_list_weights(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    pkg = load_package(out)
+    weights = pkg.list_weights()
+    assert "nominal" in weights
+    assert "base_mc_weight" in weights
+
+
+def test_list_observables(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    pkg = load_package(out)
+    observables = pkg.list_observables()
+    assert observables == ["pT_ll", "pT_l1"]
+
+
+def test_summary_keys(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    pkg = load_package(out)
+    summary = pkg.summary()
+    assert "format_version" in summary
+    assert "event_count" in summary
+    assert "observables" in summary
+    assert "weights" in summary
+    assert "checksum_sha256" in summary
+
+
+def test_summary_includes_checksum(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    pkg = load_package(out)
+    assert len(pkg.summary()["checksum_sha256"]) == 64
+
+
+def test_unsupported_format_version_raises(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    metadata_path = out / "metadata.yaml"
+    with metadata_path.open("r", encoding="utf-8") as stream:
+        metadata = yaml.safe_load(stream)
+    metadata["format_version"] = "99.0"
+    with metadata_path.open("w", encoding="utf-8") as stream:
+        yaml.safe_dump(metadata, stream)
+    with pytest.raises(UnsupportedFormatVersion):
+        load_package(out)
+
+
+def test_get_unknown_weight_raises_typed_exception(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    pkg = load_package(out)
+    with pytest.raises(PackageReadError, match="Unknown metadata-declared weight"):
+        pkg.get_weights("does_not_exist")
+
+
+def test_function_get_weights_missing_column_raises_typed_exception(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    metadata = load_metadata(out)
+    events = pkg_events_without_weights = load_package(out).load_events(columns=["pT_ll"])
+    assert "weights_nominal" not in pkg_events_without_weights.columns
+    with pytest.raises(PackageReadError, match="not present"):
+        get_weights(events, metadata)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,73 @@
+"""Tests for metadata schema validation."""
+
+import pytest
+import yaml
+
+from omnifold_publication.schema import Metadata, validate_metadata
+from omnifold_publication.writer import write_package
+
+
+def test_schema_validates_spec_metadata():
+    with open("spec/metadata.yaml", "r", encoding="utf-8") as stream:
+        metadata = yaml.safe_load(stream)
+    validate_metadata(metadata)
+
+
+def test_schema_validates_generated_package_metadata(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    with (out / "metadata.yaml").open("r", encoding="utf-8") as stream:
+        metadata = yaml.safe_load(stream)
+    validate_metadata(metadata)
+
+
+def test_schema_rejects_missing_required_top_level_field():
+    metadata = {
+        "format_version": "0.1",
+        "weights": {"nominal": "weights_nominal", "base_mc_weight": "weight_mc"},
+        "normalization": {
+            "luminosity": "unknown",
+            "cross_section": "unknown",
+            "event_weights_normalized": True,
+        },
+    }
+    with pytest.raises(ValueError, match="observables"):
+        validate_metadata(metadata)
+
+
+def test_schema_accepts_minimal_metadata():
+    metadata = {
+        "format_version": "0.1",
+        "observables": [{"name": "pT_ll", "description": "pT", "units": "GeV"}],
+        "weights": {"nominal": "weights_nominal", "base_mc_weight": "weight_mc"},
+        "normalization": {
+            "luminosity": "unknown",
+            "cross_section": "unknown",
+            "event_weights_normalized": True,
+        },
+    }
+    validate_metadata(metadata)
+
+
+def test_schema_accepts_unknown_iteration_count():
+    metadata = {
+        "format_version": "0.1",
+        "observables": [{"name": "pT_ll", "description": "pT", "units": "GeV"}],
+        "weights": {"nominal": "weights_nominal", "base_mc_weight": "weight_mc"},
+        "normalization": {
+            "luminosity": "unknown",
+            "cross_section": "unknown",
+            "event_weights_normalized": True,
+        },
+        "training": {
+            "algorithm": "OmniFold",
+            "iterations": "unknown",
+            "architecture": "unknown",
+        },
+    }
+    model = Metadata(**metadata)
+    assert model.training is not None
+    assert model.training.iterations == "unknown"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,0 +1,74 @@
+"""Tests for writer.py hardening."""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+import yaml
+
+from omnifold_publication.exceptions import PackageWriteError
+from omnifold_publication.writer import write_package
+
+
+def test_write_package_missing_input_raises(tmp_path):
+    with pytest.raises(PackageWriteError, match="Input file not found"):
+        write_package(
+            input_path=tmp_path / "nonexistent.h5",
+            output_dir=tmp_path / "out",
+        )
+
+
+def test_write_package_creates_checksum(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    with (out / "metadata.yaml").open("r", encoding="utf-8") as stream:
+        metadata = yaml.safe_load(stream)
+    assert "checksum_sha256" in metadata["publication"]
+    assert len(metadata["publication"]["checksum_sha256"]) == 64
+
+
+def test_write_package_custom_observables(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        observables=["pT_ll"],
+        event_count=100,
+    )
+    df = pd.read_parquet(out / "events.parquet")
+    assert "pT_ll" in df.columns
+    assert "pT_l1" not in df.columns
+
+
+def test_write_package_custom_observables_metadata(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        observables=["pT_ll"],
+        event_count=100,
+    )
+    with (out / "metadata.yaml").open("r", encoding="utf-8") as stream:
+        metadata = yaml.safe_load(stream)
+    assert [observable["name"] for observable in metadata["observables"]] == ["pT_ll"]
+
+
+def test_write_package_preserves_event_id_when_present(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    df = pd.read_parquet(out / "events.parquet")
+    assert "event_id" in df.columns
+
+
+def test_write_package_returns_output_path(source_hdf, tmp_path):
+    out = write_package(
+        input_path=source_hdf,
+        output_dir=tmp_path / "pkg",
+        event_count=100,
+    )
+    assert out == tmp_path / "pkg"
+    assert Path(out, "metadata.yaml").exists()


### PR DESCRIPTION
## Summary

This PR hardens the OmniFold publication package prototype into a more production-ready core package. It adds typed exceptions, checksum generation and verification, configurable observable export, reader inspection APIs, Pydantic-backed metadata validation, and real-data integration tests.

The package can now write, load, inspect, validate, and use a nominal OmniFold publication package to compute weighted histograms.

---

## What Changed

### Writer hardening

- Added clear input-file existence checks
- Added typed writer errors via `PackageWriteError`
- Added SHA-256 checksum generation for `events.parquet`
- Stored the checksum in `metadata.yaml` under `publication.checksum_sha256`
- Added `observables=` support to `write_package()` so users are no longer limited to the default `pT_ll` and `pT_l1` columns
- Fixed real-data normalization precision by computing `expected_nominal_sumw` with float64 behavior

### Reader API improvements

- Added `pkg.list_observables()`
- Added `pkg.list_weights()`
- Added `pkg.summary()`
- Replaced generic reader errors with typed exceptions:
  - `PackageReadError`
  - `UnsupportedFormatVersion`

### Validation improvements

- Integrated the Pydantic v2 metadata schema into `validate_package()`
- Added checksum verification for `events.parquet`
- `ensure_valid_package()` now raises `PackageValidationError`
- Validation still checks:
  - metadata structure
  - supported format version
  - events file presence
  - required columns
  - event count consistency
  - event alignment
  - finite weights
  - normalization consistency

### Schema updates

- Extended `schema.py` to validate both:
  - project-level metadata in `spec/metadata.yaml`
  - generated package metadata from `write_package()`
- Added support for the generated `publication` block

### Public API

- Exported new exception classes from `omnifold_publication.__init__`

---

## New Tests

Added tests for:

- writer hardening
- checksum generation and validation
- reader API methods
- typed exceptions
- schema validation
- real-data integration against local HDF5 files

New test files include:

- `tests/test_writer.py`
- `tests/test_reader_api.py`
- `tests/test_checksum.py`
- `tests/test_schema.py`
- `tests/test_real_data_integration.py`

---

## Real Data Coverage

Added skipped-when-missing integration tests for:

- `data/multifold.h5`
- `data/multifold_sherpa.h5`
- `data/multifold_nonDY.h5`

Each real-data test writes a 50,000-row package and validates it.

The package was also manually run on the full local datasets, including a full-column export with all 24 observables. All generated packages validated successfully.

---

## Current User Workflow

```python
from omnifold_publication import write_package, load_package
import numpy as np

write_package(
    input_path="data/multifold.h5",
    output_dir="zjets_nominal/",
    event_count=50_000,
)

pkg = load_package("zjets_nominal/")
pkg.validate()

print(pkg.summary())
print(pkg.list_observables())
print(pkg.list_weights())

df = pkg.load_events(columns=["pT_ll"])
w = pkg.get_weights("nominal")

hist, edges = np.histogram(df["pT_ll"], bins=30, weights=w)
```

## Test Status 
50 passed